### PR TITLE
updated scratchpad namespace to match component

### DIFF
--- a/cytoscape-autopan-on-drag.js
+++ b/cytoscape-autopan-on-drag.js
@@ -35,7 +35,7 @@
             eleOrCy.scratch("_autopanOnDrag", {});
         }
 
-        var scratchPad = eleOrCy.scratch("_undoRedo");
+        var scratchPad = eleOrCy.scratch("_autopanOnDrag");
 
         return ( name === undefined ) ? scratchPad : scratchPad[name];
     }


### PR DESCRIPTION
The autopan extension had a scratchpad namespace reference to "_undoRedo" which did not exist. This was likely just a minor copy/paste error from the undo redo extension.

Fixes #10 